### PR TITLE
Update CollectionRepository to match statche implementation

### DIFF
--- a/src/CollectionRepository.php
+++ b/src/CollectionRepository.php
@@ -6,7 +6,7 @@ use Statamic\Stache\Repositories\CollectionRepository as StacheRepository;
 
 class CollectionRepository extends StacheRepository
 {
-    public function updateEntryUris($collection)
+    public function updateEntryUris($collection, $ids = null)
     {
         $collection
             ->queryEntries()

--- a/src/EntryQueryBuilder.php
+++ b/src/EntryQueryBuilder.php
@@ -43,7 +43,7 @@ class EntryQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         return parent::get($columns);
     }
 
-    public function paginate($perPage = null, $columns = ['*'])
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $this->addTaxonomyWheres();
 


### PR DESCRIPTION
The method is missing the `$ids` parameter. As such, the install fails. Adding the `$ids` parameter and defaulting to null as per the Statche implementation allows installation of the package.

There were also missing parameters in the EntryQueryBuilder paginate method.